### PR TITLE
Turn on compareJsDoc

### DIFF
--- a/test/com/google/javascript/jscomp/AggressiveInlineAliasesTest.java
+++ b/test/com/google/javascript/jscomp/AggressiveInlineAliasesTest.java
@@ -43,25 +43,28 @@ public class AggressiveInlineAliasesTest extends CompilerTestCase {
   @Override
   public void setUp() {
     enableNormalize();
-    compareJsDoc = false;
   }
 
   public void test_b19179602() {
     test(
-        "var a = {};"
-            + "/** @constructor */ a.b = function() {};"
-            + "a.b.staticProp = 5;"
-            + "function f() { "
-            + "  while (true) { "
-            + "    var b = a.b;"
-            + "    alert(b.staticProp); } }",
-        "var a = {};"
-            + "a.b = function() {};"
-            + "a.b.staticProp = 5;"
-            + "function f() {"
-            + "  for(; true; ) {"
-            + "    var b = a.b;"
-            + "    alert(b.staticProp); } }",
+    	LINE_JOINER.join(
+        "var a = {};",
+        "/** @constructor */ a.b = function() {};",
+        "a.b.staticProp = 5;",
+        "/** @constructor */",
+        "function f() { ",
+        "  while (true) { ",
+        "    var b = a.b;",
+        "    alert(b.staticProp); } }"),
+    	LINE_JOINER.join(
+        "var a = {};",
+        "/** @constructor */ a.b = function() {};",
+        "a.b.staticProp = 5;",
+        "/** @constructor */",
+        "function f() {",
+        "  for(; true; ) {",
+        "    var b = a.b;",
+        "    alert(b.staticProp); } }"),
         null,
         AggressiveInlineAliases.UNSAFE_CTOR_ALIASING);
   }
@@ -134,21 +137,21 @@ public class AggressiveInlineAliasesTest extends CompilerTestCase {
   public void testAddPropertyToChildTypeOfUncollapsibleObjectInLocalScope() {
     test(
         LINE_JOINER.join(
-            "var a = {};",
-            "a.b = function () {};",
-            "a.b.x = 0;",
-            "var c = a;",
-            "(function() { a.b.y = 1; })();",
-            "a.b.x;",
-            "a.b.y;"),
+        "var a = {};",
+        "a.b = function () {};",
+        "a.b.x = 0;",
+        "var c = a;",
+        "(function() { a.b.y = 1; })();",
+        "a.b.x;",
+        "a.b.y;"),
         LINE_JOINER.join(
-            "var a = {};",
-            "a.b = function() {};",
-            "a.b.x = 0;",
-            "var c = null;",
-            "(function() { a.b.y = 1; })();",
-            "a.b.x;",
-            "a.b.y;"));
+        "var a = {};",
+        "a.b = function() {};",
+        "a.b.x = 0;",
+        "var c = null;",
+        "(function() { a.b.y = 1; })();",
+        "a.b.x;",
+        "a.b.y;"));
   }
 
   public void testAddPropertyToUncollapsibleCtorInLocalScopeDepth1() {
@@ -288,27 +291,32 @@ public class AggressiveInlineAliasesTest extends CompilerTestCase {
 
   public void testCollapsePropertiesOfClass1() {
     test(
-        "var namespace = function() {};"
-            + "goog.inherits(namespace, Object);"
-            + "namespace.includeExtraParam = true;"
-            + "/** @enum { number } */"
-            + "namespace.Param = { param1: 1, param2: 2 };"
-            + "if (namespace.includeExtraParam) namespace.Param.optParam = 3;"
-            + "function f() { "
-            + "  var Param = namespace.Param;"
-            + "  log(namespace.Param.optParam);"
-            + "  log(Param.optParam);"
-            + "}",
-        "var namespace = function() {};"
-            + "goog.inherits(namespace,Object);"
-            + "namespace.includeExtraParam = true;"
-            + "namespace.Param = { param1: 1,param2: 2 };"
-            + "if(namespace.includeExtraParam) namespace.Param.optParam = 3;"
-            + "function f() {"
-            + "  var Param = null;"
-            + "  log(namespace.Param.optParam);"
-            + "  log(namespace.Param.optParam);"
-            + "}");
+    	LINE_JOINER.join(
+        "/** @constructor */ var namespace = function() {};",
+        "goog.inherits(namespace, Object);",
+        "namespace.includeExtraParam = true;",
+        "/** @enum { number } */",
+        "namespace.Param = { param1: 1, param2: 2 };",
+        "if (namespace.includeExtraParam) namespace.Param.optParam = 3;",
+        "/** @constructor */",
+        "function f() { ",
+        "  var Param = namespace.Param;",
+        "  log(namespace.Param.optParam);",
+        "  log(Param.optParam);",
+        "}"),
+    	LINE_JOINER.join(
+        "/** @constructor */ var namespace = function() {};",
+        "goog.inherits(namespace,Object);",
+        "namespace.includeExtraParam = true;",
+        "/** @enum { number } */",
+        "namespace.Param = { param1: 1,param2: 2 };",
+        "if(namespace.includeExtraParam) namespace.Param.optParam = 3;",
+        "/** @constructor */",
+        "function f() {",
+        "  var Param = null;",
+        "  log(namespace.Param.optParam);",
+        "  log(namespace.Param.optParam);",
+        "}"));
   }
 
   public void testCollapsePropertiesOfClass2() {
@@ -357,12 +365,18 @@ public class AggressiveInlineAliasesTest extends CompilerTestCase {
 
   public void testDontCrashCtorAliasWithEnum() {
     test(
-        "var ns = {};"
-            + "ns.Foo = function () {};"
-            + "var Bar = ns.Foo;"
-            + "/** @const @enum */"
-            + "Bar.prop = { A: 1 };",
-        "var ns = {};" + "ns.Foo = function() {};" + "var Bar = null;" + "ns.Foo.prop = { A: 1 }");
+    	LINE_JOINER.join(
+        "var ns = {};",
+        "/** @constructor */ ns.Foo = function () {};",
+        "var Bar = ns.Foo;",
+        "/** @const @enum */",
+        "Bar.prop = { A: 1 };"),
+    	LINE_JOINER.join(
+        "var ns = {};",
+        "/** @constructor */ ns.Foo = function() {};",
+        "var Bar = null;",
+        "/** @const @enum */",
+        "ns.Foo.prop = { A: 1 }"));
   }
 
   public void testFunctionAlias2() {
@@ -525,21 +539,24 @@ public class AggressiveInlineAliasesTest extends CompilerTestCase {
 
   public void testLocalAliasOfEnumWithInstanceofCheck() {
     test(
-        "var Enums = function() {};"
-            + "/** @enum { number } */"
-            + "Enums.Fruit = { APPLE: 1, BANANA: 2 };"
-            + "function foo(f) {"
-            + "if (f instanceof Enums) { alert('what?'); return; }"
-            + "var Fruit = Enums.Fruit;"
-            + "if (f == Fruit.APPLE) alert('apple');"
-            + "if (f == Fruit.BANANA) alert('banana'); }",
-        "var Enums = function() {};"
-            + "Enums.Fruit = { APPLE: 1,BANANA: 2 };"
-            + "function foo(f) {"
-            + "if (f instanceof Enums) { alert('what?'); return; }"
-            + "var Fruit = null;"
-            + "if(f == Enums.Fruit.APPLE) alert('apple');"
-            + "if(f == Enums.Fruit.BANANA) alert('banana'); }");
+    	LINE_JOINER.join(
+        "/** @constructor */ var Enums = function() {};",
+        "/** @enum { number } */",
+        "Enums.Fruit = { APPLE: 1, BANANA: 2 };",
+        "/** @constructor */ function foo(f) {",
+        "if (f instanceof Enums) { alert('what?'); return; }",
+        "var Fruit = Enums.Fruit;",
+        "if (f == Fruit.APPLE) alert('apple');",
+        "if (f == Fruit.BANANA) alert('banana'); }"),
+    	LINE_JOINER.join(
+        "/** @constructor */ var Enums = function() {};",
+        "/** @enum { number } */",
+        "Enums.Fruit = { APPLE: 1,BANANA: 2 };",
+        "/** @constructor */ function foo(f) {",
+        "if (f instanceof Enums) { alert('what?'); return; }",
+        "var Fruit = null;",
+        "if(f == Enums.Fruit.APPLE) alert('apple');",
+        "if(f == Enums.Fruit.BANANA) alert('banana'); }"));
   }
 
   public void testLocalAliasOfFunction() {

--- a/test/com/google/javascript/jscomp/CheckAccessControlsTest.java
+++ b/test/com/google/javascript/jscomp/CheckAccessControlsTest.java
@@ -392,22 +392,22 @@ public final class CheckAccessControlsTest extends TypeICompilerTestCase {
 
   public void testPrivateAccessForProperties5() {
     test(
-        new String[] {
-          LINE_JOINER.join(
-              "/** @constructor */",
-              "function Parent () {",
-              "  /** @private */",
-              "  this.prop = 'foo';",
-              "};"),
-          LINE_JOINER.join(
-              "/**",
-              " * @constructor",
-              " * @extends {Parent}",
-              " */",
-              "function Child() {",
-              "  this.prop = 'asdf';",
-              "}",
-              "Child.prototype = new Parent();")
+    	new String[] {
+    		LINE_JOINER.join(
+    		"/** @constructor */",
+    		"function Parent () {",
+    		"  /** @private */",
+    		"  this.prop = 'foo';",
+    		"};"),
+    		LINE_JOINER.join(
+    		"/**",
+    		" * @constructor",
+    		" * @extends {Parent}",
+    		" */",
+    		"function Child() {",
+    		"  this.prop = 'asdf';",
+    		"}",
+    		"Child.prototype = new Parent();")
         },
         null,
         BAD_PRIVATE_PROPERTY_ACCESS,
@@ -418,25 +418,25 @@ public final class CheckAccessControlsTest extends TypeICompilerTestCase {
   public void testPrivateAccessForProperties6() {
     test(
         new String[] {
-          LINE_JOINER.join(
-              "goog.provide('x.y.z.Parent');",
-              "",
-              "/** @constructor */",
-              "x.y.z.Parent = function() {",
-              "  /** @private */",
-              "  this.prop = 'foo';",
-              "};"),
-          LINE_JOINER.join(
-              "goog.require('x.y.z.Parent');",
-              "",
-              "/**",
-              " * @constructor",
-              " * @extends {x.y.z.Parent}",
-              " */",
-              "function Child() {",
-              "  this.prop = 'asdf';",
-              "}",
-              "Child.prototype = new x.y.z.Parent();")
+        	LINE_JOINER.join(
+            "goog.provide('x.y.z.Parent');",
+            "",
+            "/** @constructor */",
+            "x.y.z.Parent = function() {",
+            "  /** @private */",
+            "  this.prop = 'foo';",
+            "};"),
+        	LINE_JOINER.join(
+            "goog.require('x.y.z.Parent');",
+            "",
+            "/**",
+            " * @constructor",
+            " * @extends {x.y.z.Parent}",
+            " */",
+            "function Child() {",
+            "  this.prop = 'asdf';",
+            "}",
+            "Child.prototype = new x.y.z.Parent();")
         },
         null,
         BAD_PRIVATE_PROPERTY_ACCESS,
@@ -447,14 +447,14 @@ public final class CheckAccessControlsTest extends TypeICompilerTestCase {
   public void testPrivateAccess_googModule() {
     String[] js = new String[] {
           LINE_JOINER.join(
-              "goog.module('example.One');",
-              "/** @constructor */ function One() {}",
-              "/** @private */ One.prototype.m = function() {};",
-              "exports = One;"),
+          "goog.module('example.One');",
+          "/** @constructor */ function One() {}",
+          "/** @private */ One.prototype.m = function() {};",
+          "exports = One;"),
           LINE_JOINER.join(
-              "goog.module('example.two');",
-              "var One = goog.require('example.One');",
-              "(new One()).m();"),
+          "goog.module('example.two');",
+          "var One = goog.require('example.One');",
+          "(new One()).m();"),
         };
 
     this.mode = TypeInferenceMode.OTI_ONLY;
@@ -712,15 +712,15 @@ public final class CheckAccessControlsTest extends TypeICompilerTestCase {
         SourceFile.fromCode(
             "foo.js",
             LINE_JOINER.join(
-                "goog.provide('Foo');",
-                "/** @interface */ Foo = function() {};",
-                "/** @protected */ Foo.prop = {};")),
+            "goog.provide('Foo');",
+            "/** @interface */ Foo = function() {};",
+            "/** @protected */ Foo.prop = {};")),
         SourceFile.fromCode(
             "bar.js",
             LINE_JOINER.join(
-                "goog.require('Foo');",
-                "/** @constructor @implements {Foo} */",
-                "function Bar() { Foo.prop; };"))),
+            "goog.require('Foo');",
+            "/** @constructor @implements {Foo} */",
+            "function Bar() { Foo.prop; };"))),
         null, null);
 }
 
@@ -729,27 +729,27 @@ public final class CheckAccessControlsTest extends TypeICompilerTestCase {
         SourceFile.fromCode(
             "a.js",
             LINE_JOINER.join(
-                "goog.provide('A');",
-                "/** @constructor */",
-                "var A = function() {",
-                "  /**",
-                "   * @type {?String}",
-                "   * @protected",
-                "   */",
-                "  this.prop;",
-                "}")),
+            "goog.provide('A');",
+            "/** @constructor */",
+            "var A = function() {",
+            "  /**",
+            "   * @type {?String}",
+            "   * @protected",
+            "   */",
+            "  this.prop;",
+            "}")),
         SourceFile.fromCode(
             "b.js",
             LINE_JOINER.join(
-                "goog.require('A');",
-                "/**",
-                " * @constructor",
-                " * @extends {A}",
-                " */",
-                "var B = function() {",
-                "  this.prop.length;",
-                "  this.prop.length;",
-                "};"))),
+            "goog.require('A');",
+            "/**",
+            " * @constructor",
+            " * @extends {A}",
+            " */",
+            "var B = function() {",
+            "  this.prop.length;",
+            "  this.prop.length;",
+            "};"))),
         null, null);
   }
 
@@ -761,42 +761,42 @@ public final class CheckAccessControlsTest extends TypeICompilerTestCase {
         SourceFile.fromCode(
             "a.js",
             LINE_JOINER.join(
-                "goog.provide('A');",
-                "/** @constructor */",
-                "var A = function() {}",
-                "/** @protected */",
-                "A.prototype.method = function() {};")),
+            "goog.provide('A');",
+            "/** @constructor */",
+            "var A = function() {}",
+            "/** @protected */",
+            "A.prototype.method = function() {};")),
         SourceFile.fromCode(
             "b1.js",
             LINE_JOINER.join(
-                "goog.require('A');",
-                "goog.provide('B1');",
-                "/** @constructor @extends {A} */",
-                "var B1 = function() {};",
-                "/** @override */",
-                "B1.prototype.method = function() {};")),
+            "goog.require('A');",
+            "goog.provide('B1');",
+            "/** @constructor @extends {A} */",
+            "var B1 = function() {};",
+            "/** @override */",
+            "B1.prototype.method = function() {};")),
         SourceFile.fromCode(
             "b2.js",
             LINE_JOINER.join(
-                "goog.require('A');",
-                "goog.provide('B2');",
-                "/** @constructor @extends {A} */",
-                "var B2 = function() {};",
-                "/** @override */",
-                "B2.prototype.method = function() {};")),
+            "goog.require('A');",
+            "goog.provide('B2');",
+            "/** @constructor @extends {A} */",
+            "var B2 = function() {};",
+            "/** @override */",
+            "B2.prototype.method = function() {};")),
         SourceFile.fromCode(
             "c.js",
             LINE_JOINER.join(
-                "goog.require('B1');",
-                "goog.require('B2');",
-                "/**",
-                " * @param {!B1} b1",
-                " * @constructor",
-                " * @extends {B2}",
-                " */",
-                "var C = function(b1) {",
-                "  var x = b1.method();",
-                "};"))),
+            "goog.require('B1');",
+            "goog.require('B2');",
+            "/**",
+            " * @param {!B1} b1",
+            " * @constructor",
+            " * @extends {B2}",
+            " */",
+            "var C = function(b1) {",
+            "  var x = b1.method();",
+            "};"))),
         null, null);
   }
 
@@ -1226,82 +1226,94 @@ public final class CheckAccessControlsTest extends TypeICompilerTestCase {
   }
 
   public void testFileoverviewVisibilityDoesNotApplyToGoogProvidedNamespace1() {
-    // Don't compare the generated JsDoc. It includes annotations we're not interested in,
-    // like @inherited.
-    compareJsDoc = false;
-
     test(
         ImmutableList.of(
             SourceFile.fromCode("foo.js", "goog.provide('foo');"),
             SourceFile.fromCode(
                 Compiler.joinPathParts("foo", "bar.js"),
-                "/**\n"
-                + "  * @fileoverview\n"
-                + "  * @package\n"
-                + "  */\n"
-                + "goog.provide('foo.bar');"),
+                LINE_JOINER.join(
+                "/**\n",
+                "  * @fileoverview\n",
+                "  * @package\n",
+                "  */\n",
+                "goog.provide('foo.bar');")),
             SourceFile.fromCode("bar.js", "goog.require('foo')")),
-        ImmutableList.of(SourceFile.fromCode("foo.js", "var foo={};"),
-            SourceFile.fromCode(Compiler.joinPathParts("foo", "bar.js"), "foo.bar={};"),
+        ImmutableList.of(
+        	SourceFile.fromCode("foo.js", "/** @const */ var foo={};"),
+            SourceFile.fromCode(
+            	Compiler.joinPathParts("foo", "bar.js"),
+            	LINE_JOINER.join(
+                "/**\n",
+                "  * @fileoverview\n",
+                "  * @package\n",
+                "  */\n",
+            	"/** @const */ foo.bar={};")),
             SourceFile.fromCode("bar.js", "")),
         null, null);
-
-    compareJsDoc = true;
   }
 
   public void testFileoverviewVisibilityDoesNotApplyToGoogProvidedNamespace2() {
-    // Don't compare the generated JsDoc. It includes annotations we're not interested in,
-    // like @inherited.
-    compareJsDoc = false;
-
     test(
         ImmutableList.of(
             SourceFile.fromCode(
                 Compiler.joinPathParts("foo", "bar.js"),
-                "/**\n"
-                + "  * @fileoverview\n"
-                + "  * @package\n"
-                + "  */\n"
-                + "goog.provide('foo.bar');"),
+                LINE_JOINER.join(
+                "/**\n",
+                "  * @fileoverview\n",
+                "  * @package\n",
+                "  */\n",
+                "goog.provide('foo.bar');")),
             SourceFile.fromCode("foo.js", "goog.provide('foo');"),
             SourceFile.fromCode(
                 "bar.js",
-                "goog.require('foo');\n"
-                + "var x = foo;")),
-        ImmutableList.of(SourceFile.fromCode(Compiler.joinPathParts("foo", "bar.js"),
-                "var foo={};foo.bar={};"),
-            SourceFile.fromCode("foo.js", ""), SourceFile.fromCode("bar.js", "var x=foo")),
+                LINE_JOINER.join(
+                "goog.require('foo');\n",
+                "var x = foo;"))),
+        ImmutableList.of(
+        	SourceFile.fromCode(
+        		Compiler.joinPathParts("foo", "bar.js"),
+        		LINE_JOINER.join(
+                "/** @const */var foo={};",
+                "/**\n",
+                "  * @fileoverview\n",
+                "  * @package\n",
+                "  */\n",
+        		"/** @const */foo.bar={};")),
+            SourceFile.fromCode("foo.js", ""),
+            SourceFile.fromCode("bar.js", "var x=foo")),
         null, null);
-
-    compareJsDoc = true;
   }
 
   public void testFileoverviewVisibilityDoesNotApplyToGoogProvidedNamespace3() {
-    // Don't compare the generated JsDoc. It includes annotations we're not interested in,
-    // like @inherited.
-    compareJsDoc = false;
-
     test(
         ImmutableList.of(
             SourceFile.fromCode(
                 Compiler.joinPathParts("foo", "bar.js"),
-                "/**\n"
-                + " * @fileoverview\n"
-                + " * @package\n"
-                + " */\n"
-                + "goog.provide('one.two');\n"
-                + "one.two.three = function(){};"),
+                LINE_JOINER.join(
+                "/**\n",
+                " * @fileoverview\n",
+                " * @package\n",
+                " */\n",
+                "goog.provide('one.two');\n",
+                "one.two.three = function(){};")),
             SourceFile.fromCode(
                 "baz.js",
-                "goog.require('one.two');\n"
-                + "var x = one.two;")),
+                LINE_JOINER.join(
+                "goog.require('one.two');\n",
+                "var x = one.two;"))),
         ImmutableList.of(
-            SourceFile.fromCode(Compiler.joinPathParts("foo", "bar.js"),
-                "var one={};one.two={};one.two.three=function(){};"),
+            SourceFile.fromCode(
+            	Compiler.joinPathParts("foo", "bar.js"),
+                LINE_JOINER.join(
+                "/** @const */ var one={};",
+                "/**\n",
+                " * @fileoverview\n",
+                " * @package\n",
+                " */\n",
+                "/** @const */ one.two={};",
+                "one.two.three=function(){};")),
             SourceFile.fromCode("baz.js", "var x=one.two")),
         null, null);
-
-    compareJsDoc = true;
   }
 
   public void testFileoverviewVisibilityDoesNotApplyToGoogProvidedNamespace4() {
@@ -1941,38 +1953,38 @@ public final class CheckAccessControlsTest extends TypeICompilerTestCase {
   public void testFinalClassCannotBeSubclassed() {
     testError(
         LINE_JOINER.join(
-            "/**",
-            " * @constructor",
-            " * @final",
-            " */ var Foo = function() {};",
-            "/**",
-            " * @constructor",
-            " * @extends {Foo}*",
-            " */ var Bar = function() {};"),
+        "/**",
+        " * @constructor",
+        " * @final",
+        " */ var Foo = function() {};",
+        "/**",
+        " * @constructor",
+        " * @extends {Foo}*",
+        " */ var Bar = function() {};"),
         EXTEND_FINAL_CLASS);
 
     testError(
         LINE_JOINER.join(
-            "/**",
-            " * @constructor",
-            " * @final",
-            " */ function Foo() {};",
-            "/**",
-            " * @constructor",
-            " * @extends {Foo}*",
-            " */ function Bar() {};"),
+        "/**",
+        " * @constructor",
+        " * @final",
+        " */ function Foo() {};",
+        "/**",
+        " * @constructor",
+        " * @extends {Foo}*",
+        " */ function Bar() {};"),
         EXTEND_FINAL_CLASS);
 
     testSame(
         LINE_JOINER.join(
-            "/**",
-            " * @constructor",
-            " * @const",
-            " */ var Foo = function() {};",
-            "/**",
-            " * @constructor",
-            " * @extends {Foo}",
-            " */ var Bar = function() {};"));
+        "/**",
+        " * @constructor",
+        " * @const",
+        " */ var Foo = function() {};",
+        "/**",
+        " * @constructor",
+        " * @extends {Foo}",
+        " */ var Bar = function() {};"));
   }
 
   public void testCircularPrototypeLink() {
@@ -1981,9 +1993,9 @@ public final class CheckAccessControlsTest extends TypeICompilerTestCase {
     // This warning already has a test: TypeCheckTest::testPrototypeLoop.
     testError(
         LINE_JOINER.join(
-            "/** @constructor @extends {Foo} */ function Foo() {}",
-            "/** @const */ Foo.prop = 1;",
-            "Foo.prop = 2;"),
+        "/** @constructor @extends {Foo} */ function Foo() {}",
+        "/** @const */ Foo.prop = 1;",
+        "Foo.prop = 2;"),
         CONST_PROPERTY_REASSIGNED_VALUE);
 
     // In OTI this next test causes a stack overflow.
@@ -1991,10 +2003,10 @@ public final class CheckAccessControlsTest extends TypeICompilerTestCase {
 
     testError(
         LINE_JOINER.join(
-            "/** @constructor */ function Foo() {}",
-            "/** @type {!Foo} */ Foo.prototype = new Foo();",
-            "/** @const */ Foo.prop = 1;",
-            "Foo.prop = 2;"),
+        "/** @constructor */ function Foo() {}",
+        "/** @type {!Foo} */ Foo.prototype = new Foo();",
+        "/** @const */ Foo.prop = 1;",
+        "Foo.prop = 2;"),
         CONST_PROPERTY_REASSIGNED_VALUE);
   }
 }

--- a/test/com/google/javascript/jscomp/CollapseVariableDeclarationsTest.java
+++ b/test/com/google/javascript/jscomp/CollapseVariableDeclarationsTest.java
@@ -23,7 +23,7 @@ package com.google.javascript.jscomp;
 public final class CollapseVariableDeclarationsTest extends CompilerTestCase {
   @Override
   public void setUp() {
-    compareJsDoc = false;
+	//unused
   }
 
   public void testCollapsing() throws Exception {
@@ -58,17 +58,41 @@ public final class CollapseVariableDeclarationsTest extends CompilerTestCase {
   }
 
   public void testAggressiveRedeclaration() {
-    test("var x = 2; foo(x);     x = 3; var y = 2;",
-         "var x = 2; foo(x); var x = 3,     y = 2;");
+    test(
+    	LINE_JOINER.join(
+		"var x = 2; foo(x);",
+		"    x = 3; var y = 2;"),
+    	LINE_JOINER.join(
+		"var x = 2; foo(x);",
+		"/** @suppress {duplicate} */",
+		"var x = 3,     y = 2;"));
 
-    test("var x = 2; foo(x);     x = 3; x = 1; var y = 2;",
-         "var x = 2; foo(x); var x = 3, x = 1,     y = 2;");
+    test(
+    	LINE_JOINER.join(
+		"var x = 2; foo(x);",
+		"    x = 3; x = 1; var y = 2;"),
+    	LINE_JOINER.join(
+		"var x = 2; foo(x);",
+		"/** @suppress {duplicate} */",
+		"var x = 3, x = 1,     y = 2;"));
 
-    test("var x = 2; foo(x);     x = 3; x = 1; var y = 2; var z = 4",
-         "var x = 2; foo(x); var x = 3, x = 1,     y = 2,     z = 4");
+    test(
+    	LINE_JOINER.join(
+		"var x = 2; foo(x);",
+		"    x = 3; x = 1; var y = 2; var z = 4"),
+    	LINE_JOINER.join(
+		"var x = 2; foo(x);",
+		"/** @suppress {duplicate} */",
+		"var x = 3, x = 1,     y = 2,     z = 4"));
 
-    test("var x = 2; foo(x);     x = 3; x = 1; var y = 2; var z = 4; x = 5",
-         "var x = 2; foo(x); var x = 3, x = 1,     y = 2,     z = 4, x = 5");
+    test(
+    	LINE_JOINER.join(
+		"var x = 2; foo(x);",
+		"    x = 3; x = 1; var y = 2; var z = 4; x = 5"),
+    	LINE_JOINER.join(
+		"var x = 2; foo(x);",
+		"/** @suppress {duplicate} */",
+		"var x = 3, x = 1,     y = 2,     z = 4, x = 5"));
   }
 
   public void testAggressiveRedeclarationInFor() {

--- a/test/com/google/javascript/jscomp/GenerateExportsTest.java
+++ b/test/com/google/javascript/jscomp/GenerateExportsTest.java
@@ -30,7 +30,6 @@ public final class GenerateExportsTest extends Es6CompilerTestCase {
 
   public GenerateExportsTest() {
     super(EXTERNS);
-    compareJsDoc = false;
   }
 
   @Override
@@ -59,60 +58,72 @@ public final class GenerateExportsTest extends Es6CompilerTestCase {
 
   public void testExportSymbol() {
     test("/** @export */function foo() {}",
-         "function foo(){}google_exportSymbol(\"foo\",foo)");
+         "/** @export */function foo(){}google_exportSymbol(\"foo\",foo)");
   }
 
   public void testExportSymbolAndProperties() {
-    test("/** @export */function foo() {}" +
-         "/** @export */foo.prototype.bar = function() {}",
-         "function foo(){}" +
-         "google_exportSymbol(\"foo\",foo);" +
-         "foo.prototype.bar=function(){};" +
-         "goog.exportProperty(foo.prototype,\"bar\",foo.prototype.bar)");
+    test(
+    	LINE_JOINER.join(
+		"/** @export */function foo() {}",
+		"/** @export */foo.prototype.bar = function() {}"),
+    	LINE_JOINER.join(
+		"/** @export */function foo(){}",
+    	"google_exportSymbol(\"foo\",foo);",
+    	"/** @export */foo.prototype.bar=function(){};",
+    	"goog.exportProperty(foo.prototype,\"bar\",foo.prototype.bar)"));
   }
 
   public void testExportPrototypeProperty() {
     test(
         LINE_JOINER.join(
-            "function Foo() {}",
-            "/** @export */ Foo.prototype.bar = function() {};"),
+        "function Foo() {}",
+        "/** @export */ Foo.prototype.bar = function() {};"),
         LINE_JOINER.join(
-            "function Foo() {}",
-            "Foo.prototype.bar = function(){};",
-            "goog.exportProperty(Foo.prototype, 'bar', Foo.prototype.bar);"));
+        "function Foo() {}",
+        "/** @export */ Foo.prototype.bar = function(){};",
+        "goog.exportProperty(Foo.prototype, 'bar', Foo.prototype.bar);"));
   }
 
   public void testExportSymbolAndConstantProperties() {
-    test("/** @export */function foo() {}" +
-         "/** @export */foo.BAR = 5;",
-         "function foo(){}" +
-         "google_exportSymbol(\"foo\",foo);" +
-         "foo.BAR=5;" +
-         "goog.exportProperty(foo,\"BAR\",foo.BAR)");
+    test(
+    	LINE_JOINER.join(
+		"/** @export */function foo() {}",
+		"/** @export */foo.BAR = 5;"),
+    	LINE_JOINER.join(
+		"/** @export */function foo(){}",
+		"google_exportSymbol(\"foo\",foo);",
+		"/** @export */foo.BAR=5;",
+		"goog.exportProperty(foo,\"BAR\",foo.BAR)"));
   }
 
   public void testExportVars() {
-    test("/** @export */var FOO = 5",
-         "var FOO=5;" +
-         "google_exportSymbol('FOO',FOO)");
+    test(
+    	"/** @export */var FOO = 5",
+    	LINE_JOINER.join(
+		"/** @export */var FOO=5;",
+		"google_exportSymbol('FOO',FOO)"));
   }
 
   public void testExportLet() {
     testEs6("/** @export */let FOO = 5",
-         "let FOO = 5;" +
-         "google_exportSymbol('FOO', FOO)");
+    	LINE_JOINER.join(
+		"/** @export */let FOO = 5;",
+		"google_exportSymbol('FOO', FOO)"));
   }
 
   public void testExportConst() {
     testEs6("/** @export */const FOO = 5",
-         "const FOO = 5;" +
-         "google_exportSymbol('FOO', FOO)");
+    	LINE_JOINER.join(
+		"/** @export */const FOO = 5;",
+		"google_exportSymbol('FOO', FOO)"));
   }
 
   public void testExportEs6ArrowFunction() {
-    testEs6("/** @export */var fn = ()=>{};",
-          "var fn = ()=>{};"
-        + "google_exportSymbol('fn', fn)");
+    testEs6(
+    	"/** @export */var fn = ()=>{};",
+    	LINE_JOINER.join(
+		"/** @export */var fn = ()=>{};",
+    	"google_exportSymbol('fn', fn)"));
   }
 
   public void testNoExport() {
@@ -125,13 +136,15 @@ public final class GenerateExportsTest extends Es6CompilerTestCase {
    */
   public void testNestedVarAssign() {
     this.allowNonGlobalExports = false;
-    testError(LINE_JOINER.join(
+    testError(
+    	LINE_JOINER.join(
         "var BAR;",
         "/** @export */ var FOO = BAR = 5"),
         FindExportableNodes.NON_GLOBAL_ERROR);
 
     this.allowNonGlobalExports = true;
-    testError(LINE_JOINER.join(
+    testError(
+    	LINE_JOINER.join(
         "var BAR;",
         "/** @export */ var FOO = BAR = 5"),
         FindExportableNodes.EXPORT_ANNOTATION_NOT_ALLOWED);
@@ -143,13 +156,15 @@ public final class GenerateExportsTest extends Es6CompilerTestCase {
    */
   public void testNestedAssign() {
     this.allowNonGlobalExports = false;
-    testError(LINE_JOINER.join(
+    testError(
+    	LINE_JOINER.join(
         "var BAR;var FOO = {};",
         "/** @export */FOO.test = BAR = 5"),
         FindExportableNodes.NON_GLOBAL_ERROR);
 
     this.allowNonGlobalExports = true;
-    testError(LINE_JOINER.join(
+    testError(
+    	LINE_JOINER.join(
         "var BAR;var FOO = {};",
         "/** @export */FOO.test = BAR = 5"),
         FindExportableNodes.EXPORT_ANNOTATION_NOT_ALLOWED);
@@ -173,82 +188,94 @@ public final class GenerateExportsTest extends Es6CompilerTestCase {
 
   public void testExportClass() {
     test("/** @export */ function G() {} foo();",
-         "function G() {} google_exportSymbol('G', G); foo();");
+         "/** @export */ function G() {} google_exportSymbol('G', G); foo();");
   }
 
   public void testExportClassMember() {
-    test(LINE_JOINER.join(
-          "/** @export */ function F() {}",
-          "/** @export */ F.prototype.method = function() {};"),
-         LINE_JOINER.join(
-          "function F() {}",
-          "google_exportSymbol('F', F);",
-          "F.prototype.method = function() {};",
-          "goog.exportProperty(F.prototype, 'method', F.prototype.method);"));
+    test(
+    	LINE_JOINER.join(
+    	"/** @export */ function F() {}",
+		"/** @export */ F.prototype.method = function() {};"),
+        LINE_JOINER.join(
+    	"/** @export */ function F() {}",
+    	"google_exportSymbol('F', F);",
+    	"/** @export */ F.prototype.method = function() {};",
+    	"goog.exportProperty(F.prototype, 'method', F.prototype.method);"));
   }
 
   public void testExportEs6ClassSymbol() {
     testEs6("/** @export */ class G {} foo();",
-            "class G {} google_exportSymbol('G', G); foo();");
+            "/** @export */ class G {} google_exportSymbol('G', G); foo();");
 
     testEs6("/** @export */ G = class {}; foo();",
-            "G = class {}; google_exportSymbol('G', G); foo();");
+            "/** @export */ G = class {}; google_exportSymbol('G', G); foo();");
   }
 
   public void testExportEs6ClassProperty() {
-    testEs6(LINE_JOINER.join(
-          "/** @export */ G = class {};",
-          "/** @export */ G.foo = class {};"),
-            LINE_JOINER.join(
-          "G = class {}; google_exportSymbol('G', G);",
-          "G.foo = class {};",
-          "goog.exportProperty(G, 'foo', G.foo)"));
+    testEs6(
+    	LINE_JOINER.join(
+		"/** @export */ G = class {};",
+		"/** @export */ G.foo = class {};"),
+        LINE_JOINER.join(
+    	"/** @export */ G = class {};",
+    	"google_exportSymbol('G', G);",
+    	"/** @public @export */ G.foo = class {};",
+    	"goog.exportProperty(G, 'foo', G.foo)"));
 
-    testEs6(LINE_JOINER.join(
-        "G = class {};",
-        "/** @export */ G.prototype.foo = class {};"),
-            LINE_JOINER.join(
-        "G = class {}; G.prototype.foo = class {};",
-        "goog.exportProperty(G.prototype, 'foo', G.prototype.foo)"));
+    testEs6(
+    	LINE_JOINER.join(
+		"G = class {};",
+		"/** @export */ G.prototype.foo = class {};"),
+        LINE_JOINER.join(
+    	"G = class {};",
+    	"/** @export @public */ G.prototype.foo = class {};",
+    	"goog.exportProperty(G.prototype, 'foo', G.prototype.foo)"));
   }
 
   public void testExportEs6ClassMembers() {
-    testEs6(LINE_JOINER.join(
-          "/** @export */ class G {",
-          "  /** @export */ method() {} }"),
-            LINE_JOINER.join(
-          "class G { method() {} }",
-          "google_exportSymbol('G', G);",
-          "goog.exportProperty(G.prototype, 'method', G.prototype.method);"));
+    testEs6(
+    	LINE_JOINER.join(
+    	"/** @export */ class G {",
+		"/** @export */ method() {} }"),
+        LINE_JOINER.join(
+    	"/** @export @public */ class G { /** @export */ method() {} }",
+    	"google_exportSymbol('G', G);",
+    	"goog.exportProperty(G.prototype, 'method', G.prototype.method);"));
 
-    testEs6(LINE_JOINER.join(
-          "/** @export */ class G {",
-          "/** @export */ static method() {} }"),
-            LINE_JOINER.join(
-          "class G { static method() {} }",
-          "google_exportSymbol('G', G);",
-          "goog.exportProperty(G, 'method', G.method);"));
+    testEs6(
+    	LINE_JOINER.join(
+		"/** @export */ class G {",
+		"/** @export */ static method() {} }"),
+        LINE_JOINER.join(
+    	"/** @export @public */ class G { /** @export */ static method() {} }",
+    	"google_exportSymbol('G', G);",
+    	"goog.exportProperty(G, 'method', G.method);"));
   }
 
   public void testGoogScopeFunctionOutput() {
     test(
         "/** @export */ $jscomp.scope.foo = /** @export */ function() {}",
-        "$jscomp.scope.foo = /** @export */ function() {};"
-            + "google_exportSymbol('$jscomp.scope.foo', $jscomp.scope.foo);");
+        LINE_JOINER.join(
+    	"/** @export */ $jscomp.scope.foo = /** @export */ function() {};",
+        "google_exportSymbol('$jscomp.scope.foo', $jscomp.scope.foo);"));
   }
 
   public void testGoogScopeClassOutput() {
     testEs6(
         "/** @export */ $jscomp.scope.foo = /** @export */ class {}",
-        "$jscomp.scope.foo = /** @export */ class {};"
-            + "google_exportSymbol('$jscomp.scope.foo', $jscomp.scope.foo);");
+        LINE_JOINER.join(
+    	"/** @export */ $jscomp.scope.foo = /** @export */ class {};",
+        "google_exportSymbol('$jscomp.scope.foo', $jscomp.scope.foo);"));
   }
 
   public void testExportSubclass() {
-    test("var goog = {}; function F() {}" +
-         "/** @export */ function G() {} goog.inherits(G, F);",
-         "var goog = {}; function F() {}" +
-         "function G() {} goog.inherits(G, F); google_exportSymbol('G', G);");
+    test(
+    	LINE_JOINER.join(
+		"var goog = {}; function F() {}",
+		"/** @export */ function G() {} goog.inherits(G, F);"),
+    	LINE_JOINER.join(
+		"var goog = {}; function F() {}",
+		"/** @export */ function G() {} goog.inherits(G, F); google_exportSymbol('G', G);"));
   }
 
   public void testExportEnum() {

--- a/test/com/google/javascript/jscomp/InlineVariablesTest.java
+++ b/test/com/google/javascript/jscomp/InlineVariablesTest.java
@@ -35,7 +35,7 @@ public final class InlineVariablesTest extends CompilerTestCase {
 
   @Override
   public void setUp() {
-    compareJsDoc = false;
+	//unused
   }
 
   @Override
@@ -857,13 +857,14 @@ public final class InlineVariablesTest extends CompilerTestCase {
   public void testLocalsOnly2() {
     inlineLocalsOnly = true;
     test(
-        "/** @const */\n" +
-        "var X=1; X;\n" +
-        "function f() {\n" +
-        "  /** @const */\n" +
-        "  var X = 1; X;\n" +
-        "}",
-        "var X=1; X; function f() {1;}");
+    	LINE_JOINER.join(
+		"/** @const */\n",
+		"var X=1; X;\n",
+		"function f() {\n",
+		"  /** @const */\n",
+		"  var X = 1; X;\n",
+		"}"),
+        "/** @const */var X=1; X; function f() {1;}");
   }
 
   public void testInlineUndefined1() {
@@ -1161,15 +1162,16 @@ public final class InlineVariablesTest extends CompilerTestCase {
 
   // GitHub issue #1234: https://github.com/google/closure-compiler/issues/1234
   public void testSwitchGithubIssue1234() {
-    testSame(LINE_JOINER.join(
-      "var x;",
-      "switch ('a') {",
-      "  case 'a':",
-      "    break;",
-      "  default:",
-      "    x = 1;",
-      "    break;",
-      "}",
-      "use(x);"));
+    testSame(
+    	LINE_JOINER.join(
+		"var x;",
+		"switch ('a') {",
+		"  case 'a':",
+		"    break;",
+		"  default:",
+		"    x = 1;",
+		"    break;",
+		"}",
+		"use(x);"));
   }
 }

--- a/test/com/google/javascript/jscomp/ReplaceIdGeneratorsTest.java
+++ b/test/com/google/javascript/jscomp/ReplaceIdGeneratorsTest.java
@@ -62,7 +62,6 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
     super.setUp();
     generatePseudoNames = false;
     previousMappings = null;
-    compareJsDoc = false;
   }
 
   @Override
@@ -103,6 +102,7 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "f1 = id('f1')"),
 
         LINE_JOINER.join(
+        "/** @consistentIdGenerator */",
         "id = function() {};",
         "f1 = 'a';",
         "f1 = 'a'"),
@@ -169,13 +169,14 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "a:f1\n" +
         "\n";
     testMap(
-        "/** @consistentIdGenerator */ id = function() {};" +
-        "f1 = id('f1');" +
-        "f1 = id('f1')",
-
-        "id = function() {};" +
-        "f1 = 'a';" +
-        "f1 = 'a'",
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ id = function() {};",
+        "f1 = id('f1');",
+        "f1 = id('f1')"),
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ id = function() {};",
+        "f1 = 'a';",
+        "f1 = 'a'"),
 
         "[id]\n" +
         "\n" +
@@ -184,26 +185,30 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
   }
 
   public void testSimple() {
-    test("/** @idGenerator */ foo.getUniqueId = function() {};" +
-         "foo.bar = foo.getUniqueId('foo_bar')",
+    test(
+    	LINE_JOINER.join(
+    	"/** @idGenerator */ foo.getUniqueId = function() {};",
+        "foo.bar = foo.getUniqueId('foo_bar')"),
+        LINE_JOINER.join(
+        "/** @idGenerator */ foo.getUniqueId = function() {};",
+        "foo.bar = 'a'"),
+        LINE_JOINER.join(
+        "/** @idGenerator */ foo.getUniqueId = function() {};",
+        "foo.bar = 'foo_bar$0'"));
 
-         "foo.getUniqueId = function() {};" +
-         "foo.bar = 'a'",
-
-         "foo.getUniqueId = function() {};" +
-         "foo.bar = 'foo_bar$0'");
-
-    test("/** @idGenerator */ goog.events.getUniqueId = function() {};" +
-        "foo1 = goog.events.getUniqueId('foo1');" +
+    test(
+    	LINE_JOINER.join(
+    	"/** @idGenerator */ goog.events.getUniqueId = function() {};",
         "foo1 = goog.events.getUniqueId('foo1');",
-
-        "goog.events.getUniqueId = function() {};" +
-        "foo1 = 'a';" +
-        "foo1 = 'b';",
-
-        "goog.events.getUniqueId = function() {};" +
-        "foo1 = 'foo1$0';" +
-        "foo1 = 'foo1$1';");
+        "foo1 = goog.events.getUniqueId('foo1');"),
+        LINE_JOINER.join(
+        "/** @idGenerator */ goog.events.getUniqueId = function() {};",
+        "foo1 = 'a';",
+        "foo1 = 'b';"),
+        LINE_JOINER.join(
+        "/** @idGenerator */ goog.events.getUniqueId = function() {};",
+        "foo1 = 'foo1$0';",
+        "foo1 = 'foo1$1';"));
   }
 
   public void testObjectLit() {
@@ -211,10 +216,10 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "/** @idGenerator */ goog.id = function() {};",
         "things = goog.id({foo1: 'test', 'foo bar': 'test'})"),
         LINE_JOINER.join(
-        "goog.id = function() {};",
+        "/** @idGenerator */ goog.id = function() {};",
         "things = {'a': 'test', 'b': 'test'}"),
         LINE_JOINER.join(
-        "goog.id = function() {};",
+        "/** @idGenerator */ goog.id = function() {};",
         "things = {'foo1$0': 'test', 'foo bar$1': 'test'}"));
   }
 
@@ -224,7 +229,7 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "/** @idGenerator {mapped} */ id = function() {};",
         "things = id({foo: 'test', 'bar': 'test'})"),
          LINE_JOINER.join(
-        "id = function() {};",
+        "/** @idGenerator {mapped} */ id = function() {};",
         "things = {':foo:': 'test', ':bar:': 'test'}"));
   }
 
@@ -234,7 +239,7 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "/** @idGenerator {xid} */ xid.object = function() {};",
         "things = xid.object({foo: 'test', 'value': 'test'})"),
         LINE_JOINER.join(
-        "xid.object = function() {};",
+        "/** @idGenerator {xid} */ xid.object = function() {};",
         "things = {'QB6rXc': 'test', 'b6Lt6c': 'test'}"));
   }
 
@@ -244,10 +249,10 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "/** @idGenerator */ goog.id = function() {};",
         "things = goog.id({})"),
         LINE_JOINER.join(
-        "goog.id = function() {};",
+        "/** @idGenerator */ goog.id = function() {};",
         "things = {}"),
         LINE_JOINER.join(
-        "goog.id = function() {};",
+        "/** @idGenerator */ goog.id = function() {};",
         "things = {}"));
   }
 
@@ -257,10 +262,10 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "/** @idGenerator */ goog.id = function() {};",
         "things = goog.id({foo: function() {}})"),
         LINE_JOINER.join(
-        "goog.id = function() {};",
+        "/** @idGenerator */ goog.id = function() {};",
         "things = {'a': function() {}}"),
         LINE_JOINER.join(
-        "goog.id = function() {};",
+        "/** @idGenerator */ goog.id = function() {};",
         "things = {'foo$0': function() {}}"));
 
     testEs6(
@@ -268,10 +273,10 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "/** @idGenerator */ goog.id = function() {};",
         "things = goog.id({foo: function*() {}})"),
         LINE_JOINER.join(
-        "goog.id = function() {};",
+        "/** @idGenerator */ goog.id = function() {};",
         "things = {'a': function*() {}}"),
         LINE_JOINER.join(
-        "goog.id = function() {};",
+        "/** @idGenerator */ goog.id = function() {};",
         "things = {'foo$0': function*() {}}"));
   }
 
@@ -304,41 +309,47 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
   }
 
   public void testSimpleConsistent() {
-    test("/** @consistentIdGenerator */ id = function() {};" +
-         "foo.bar = id('foo_bar')",
+    test(
+    	LINE_JOINER.join(
+    	"/** @consistentIdGenerator */ id = function() {};",
+        "foo.bar = id('foo_bar')"),
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ id = function() {};",
+        "foo.bar = 'a'"),
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ id = function() {};",
+        "foo.bar = 'foo_bar$0'"));
 
-         "id = function() {};" +
-         "foo.bar = 'a'",
+    test(
+    	LINE_JOINER.join(
+    	"/** @consistentIdGenerator */ id = function() {};",
+        "f1 = id('f1');",
+        "f1 = id('f1')"),
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ id = function() {};",
+        "f1 = 'a';",
+        "f1 = 'a'"),
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ id = function() {};",
+        "f1 = 'f1$0';",
+        "f1 = 'f1$0'"));
 
-         "id = function() {};" +
-         "foo.bar = 'foo_bar$0'");
-
-    test("/** @consistentIdGenerator */ id = function() {};" +
-         "f1 = id('f1');" +
-         "f1 = id('f1')",
-
-         "id = function() {};" +
-         "f1 = 'a';" +
-         "f1 = 'a'",
-
-         "id = function() {};" +
-         "f1 = 'f1$0';" +
-         "f1 = 'f1$0'");
-
-    test("/** @consistentIdGenerator */ id = function() {};" +
-        "f1 = id('f1');" +
-        "f1 = id('f1');" +
-        "f1 = id('f1')",
-
-        "id = function() {};" +
-        "f1 = 'a';" +
-        "f1 = 'a';" +
-        "f1 = 'a'",
-
-        "id = function() {};" +
-        "f1 = 'f1$0';" +
-        "f1 = 'f1$0';" +
-        "f1 = 'f1$0'");
+    test(
+    	LINE_JOINER.join(
+    	"/** @consistentIdGenerator */ id = function() {};",
+        "f1 = id('f1');",
+        "f1 = id('f1');",
+        "f1 = id('f1')"),
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ id = function() {};",
+        "f1 = 'a';",
+        "f1 = 'a';",
+        "f1 = 'a'"),
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ id = function() {};",
+        "f1 = 'f1$0';",
+        "f1 = 'f1$0';",
+        "f1 = 'f1$0'"));
   }
 
   public void testSimpleStable() {
@@ -346,7 +357,7 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "/** @stableIdGenerator */ id = function() {};" +
         "foo.bar = id('foo_bar')",
 
-        "id = function() {};" +
+        "/** @stableIdGenerator */ id = function() {};" +
         "foo.bar = '125lGg'");
 
     testNonPseudoSupportingGenerator(
@@ -354,7 +365,7 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "f1 = id('f1');" +
         "f1 = id('f1')",
 
-        "id = function() {};" +
+        "/** @stableIdGenerator */ id = function() {};" +
         "f1 = 'AAAMiw';" +
         "f1 = 'AAAMiw'");
   }
@@ -365,7 +376,7 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "/** @idGenerator {xid} */ id = function() {};",
         "foo.bar = id('foo')"),
         LINE_JOINER.join(
-        "id = function() {};",
+        "/** @idGenerator {xid} */ id = function() {};",
         "foo.bar = 'QB6rXc'"));
 
     testNonPseudoSupportingGenerator(
@@ -374,90 +385,99 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "f1 = id('foo');",
         "f1 = id('foo')"),
         LINE_JOINER.join(
-        "id = function() {};",
+        "/** @idGenerator {xid} */ id = function() {};",
         "f1 = 'QB6rXc';",
         "f1 = 'QB6rXc'"));
   }
 
   public void testVar() {
-    test("/** @consistentIdGenerator */ var id = function() {};" +
-         "foo.bar = id('foo_bar')",
-
-         "var id = function() {};" +
-         "foo.bar = 'a'",
-
-         "var id = function() {};" +
-         "foo.bar = 'foo_bar$0'");
+    test(
+    	LINE_JOINER.join(
+    	"/** @consistentIdGenerator */ var id = function() {};",
+        "foo.bar = id('foo_bar')"),
+        LINE_JOINER.join(
+        "/** @consistentIdGenerator */ var id = function() {};",
+        "foo.bar = 'a'"),
+        LINE_JOINER.join(
+        "/** @consistentIdGenerator */ var id = function() {};",
+        "foo.bar = 'foo_bar$0'"));
 
     testNonPseudoSupportingGenerator(
-        "/** @stableIdGenerator */ var id = function() {};" +
-        "foo.bar = id('foo_bar')",
-
-        "var id = function() {};" +
-        "foo.bar = '125lGg'");
+    	LINE_JOINER.join(
+        "/** @stableIdGenerator */ var id = function() {};",
+        "foo.bar = id('foo_bar')"),
+        LINE_JOINER.join(
+        "/** @stableIdGenerator */ var id = function() {};",
+        "foo.bar = '125lGg'"));
   }
 
   public void testLet() {
     testEs6(
-        "/** @consistentIdGenerator */ let id = function() {};" +
-        "foo.bar = id('foo_bar')",
-
-        "let id = function() {};" +
-        "foo.bar = 'a'",
-
-        "let id = function() {};" +
-        "foo.bar = 'foo_bar$0'");
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ let id = function() {};",
+        "foo.bar = id('foo_bar')"),
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ let id = function() {};",
+        "foo.bar = 'a'"),
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ let id = function() {};",
+        "foo.bar = 'foo_bar$0'"));
 
     testNonPseudoSupportingGeneratorEs6(
         "/** @stableIdGenerator */ let id = function() {};" +
         "foo.bar = id('foo_bar')",
 
-        "let id = function() {};" +
+        "/** @stableIdGenerator */ let id = function() {};" +
         "foo.bar = '125lGg'");
   }
 
   public void testConst() {
     testEs6(
-        "/** @consistentIdGenerator */ const id = function() {};" +
-        "foo.bar = id('foo_bar')",
-
-        "const id = function() {};" +
-        "foo.bar = 'a'",
-
-        "const id = function() {};" +
-        "foo.bar = 'foo_bar$0'");
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ const id = function() {};",
+        "foo.bar = id('foo_bar')"),
+        LINE_JOINER.join(
+        "/** @consistentIdGenerator */ const id = function() {};",
+        "foo.bar = 'a'"),
+        LINE_JOINER.join(
+        "/** @consistentIdGenerator */ const id = function() {};",
+        "foo.bar = 'foo_bar$0'"));
 
     testNonPseudoSupportingGeneratorEs6(
-        "/** @stableIdGenerator */ const id = function() {};" +
-        "foo.bar = id('foo_bar')",
-
-        "const id = function() {};" +
-        "foo.bar = '125lGg'");
+    	LINE_JOINER.join(
+        "/** @stableIdGenerator */ const id = function() {};",
+        "foo.bar = id('foo_bar')"),
+    	LINE_JOINER.join(
+        "/** @stableIdGenerator */ const id = function() {};",
+        "foo.bar = '125lGg'"));
   }
 
   public void testInObjLit() {
-    test("/** @consistentIdGenerator */ get.id = function() {};" +
-         "foo.bar = {a: get.id('foo_bar')}",
-
-         "get.id = function() {};" +
-         "foo.bar = {a: 'a'}",
-
-         "get.id = function() {};" +
-         "foo.bar = {a: 'foo_bar$0'}");
+    test(
+    	LINE_JOINER.join(
+    	"/** @consistentIdGenerator */ get.id = function() {};",
+        "foo.bar = {a: get.id('foo_bar')}"),
+    	LINE_JOINER.join(
+    	"/** @consistentIdGenerator */ get.id = function() {};",
+        "foo.bar = {a: 'a'}"),
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ get.id = function() {};",
+        "foo.bar = {a: 'foo_bar$0'}"));
 
     testNonPseudoSupportingGenerator(
-        "/** @stableIdGenerator */ get.id = function() {};" +
-        "foo.bar = {a: get.id('foo_bar')}",
-
-        "get.id = function() {};" +
-        "foo.bar = {a: '125lGg'}");
+    	LINE_JOINER.join(
+        "/** @stableIdGenerator */ get.id = function() {};",
+        "foo.bar = {a: get.id('foo_bar')}"),
+        LINE_JOINER.join(
+        "/** @stableIdGenerator */ get.id = function() {};",
+        "foo.bar = {a: '125lGg'}"));
 
     testNonPseudoSupportingGenerator(
         LINE_JOINER.join(
         "/** @idGenerator {xid} */ get.id = function() {};",
         "foo.bar = {a: get.id('foo')}"),
         LINE_JOINER.join(
-        "get.id = function() {};",
+        "/** @idGenerator {xid} */ get.id = function() {};",
         "foo.bar = {a: 'QB6rXc'}"));
   }
 
@@ -467,10 +487,10 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "/** @idGenerator {mapped}*/ id = function() {};",
         "foo.bar = {a: id('foo')}"),
         LINE_JOINER.join(
-        "id = function() {};",
+        "/** @idGenerator {mapped}*/ id = function() {};",
         "foo.bar = {a: ':foo:'}"),
         LINE_JOINER.join(
-        "id = function() {};",
+        "/** @idGenerator {mapped}*/ id = function() {};",
         "foo.bar = {a: ':foo:'}"));
   }
 
@@ -480,10 +500,10 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "/** @idGenerator {mapped}*/ id = function() {};",
         "foo.bar = id('foo');"),
         LINE_JOINER.join(
-        "id = function() {};",
+        "/** @idGenerator {mapped}*/ id = function() {};",
         "foo.bar = ':foo:';"),
         LINE_JOINER.join(
-        "id = function() {};",
+        "/** @idGenerator {mapped}*/ id = function() {};",
         "foo.bar = ':foo:';"));
   }
 
@@ -494,7 +514,7 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "foo.bar = id('foo');",
         "foo.bar = id('foo');"),
         LINE_JOINER.join(
-        "id = function() {};",
+        "/** @idGenerator {mapped}*/id = function() {};",
         "foo.bar = ':foo:';",
         "foo.bar = ':foo:';"),
         LINE_JOINER.join(
@@ -511,66 +531,70 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
         "/** @idGenerator {mapped}*/ id = function() {};",
         "foo.bar = function() { return id('foo'); };"),
         LINE_JOINER.join(
-        "id = function() {};",
+        "/** @idGenerator {mapped}*/ id = function() {};",
         "foo.bar = function() { return ':foo:'; };"),
         LINE_JOINER.join(
-        "id = function() {};",
+        "/** @idGenerator {mapped}*/ id = function() {};",
         "foo.bar = function() { return ':foo:'; };"));
   }
 
   public void testTwoGenerators() {
-    test("/** @idGenerator */ var id1 = function() {};" +
-         "/** @idGenerator */ var id2 = function() {};" +
-         "f1 = id1('1');" +
-         "f2 = id1('1');" +
-         "f3 = id2('1');" +
-         "f4 = id2('1');",
-
-         "var id1 = function() {};" +
-         "var id2 = function() {};" +
-         "f1 = 'a';" +
-         "f2 = 'b';" +
-         "f3 = 'a';" +
-         "f4 = 'b';",
-
-         "var id1 = function() {};" +
-         "var id2 = function() {};" +
-         "f1 = '1$0';" +
-         "f2 = '1$1';" +
-         "f3 = '1$0';" +
-         "f4 = '1$1';");
+    test(
+    	LINE_JOINER.join(
+    	"/** @idGenerator */ var id1 = function() {};",
+        "/** @idGenerator */ var id2 = function() {};",
+        "f1 = id1('1');",
+        "f2 = id1('1');",
+        "f3 = id2('1');",
+        "f4 = id2('1');"),
+    	LINE_JOINER.join(
+        "/** @idGenerator */ var id1 = function() {};",
+        "/** @idGenerator */ var id2 = function() {};",
+        "f1 = 'a';",
+        "f2 = 'b';",
+        "f3 = 'a';",
+        "f4 = 'b';"),
+    	LINE_JOINER.join(
+        "/** @idGenerator */ var id1 = function() {};",
+        "/** @idGenerator */ var id2 = function() {};",
+        "f1 = '1$0';",
+        "f2 = '1$1';",
+        "f3 = '1$0';",
+        "f4 = '1$1';"));
   }
 
   public void testMixedGenerators() {
-    test("/** @idGenerator */ var id1 = function() {};" +
-         "/** @consistentIdGenerator */ var id2 = function() {};" +
-         "/** @stableIdGenerator */ var id3 = function() {};" +
-         "f1 = id1('1');" +
-         "f2 = id1('1');" +
-         "f3 = id2('1');" +
-         "f4 = id2('1');" +
-         "f5 = id3('1');" +
-         "f6 = id3('1');",
-
-         "var id1 = function() {};" +
-         "var id2 = function() {};" +
-         "var id3 = function() {};" +
-         "f1 = 'a';" +
-         "f2 = 'b';" +
-         "f3 = 'a';" +
-         "f4 = 'a';" +
-         "f5 = 'AAAAMQ';" +
-         "f6 = 'AAAAMQ';",
-
-         "var id1 = function() {};" +
-         "var id2 = function() {};" +
-         "var id3 = function() {};" +
-         "f1 = '1$0';" +
-         "f2 = '1$1';" +
-         "f3 = '1$0';" +
-         "f4 = '1$0';" +
-         "f5 = 'AAAAMQ';" +
-         "f6 = 'AAAAMQ';");
+    test(
+    	LINE_JOINER.join(
+    	"/** @idGenerator */ var id1 = function() {};",
+        "/** @consistentIdGenerator */ var id2 = function() {};",
+        "/** @stableIdGenerator */ var id3 = function() {};",
+        "f1 = id1('1');",
+        "f2 = id1('1');",
+        "f3 = id2('1');",
+        "f4 = id2('1');",
+        "f5 = id3('1');",
+        "f6 = id3('1');"),
+        LINE_JOINER.join(
+        "/** @idGenerator */ var id1 = function() {};",
+        "/** @consistentIdGenerator */ var id2 = function() {};",
+        "/** @stableIdGenerator */ var id3 = function() {};",
+        "f1 = 'a';",
+        "f2 = 'b';",
+        "f3 = 'a';",
+        "f4 = 'a';",
+        "f5 = 'AAAAMQ';",
+        "f6 = 'AAAAMQ';"),
+        LINE_JOINER.join(
+        "/** @idGenerator */ var id1 = function() {};",
+        "/** @consistentIdGenerator */ var id2 = function() {};",
+        "/** @stableIdGenerator */ var id3 = function() {};",
+        "f1 = '1$0';",
+        "f2 = '1$1';",
+        "f3 = '1$0';",
+        "f4 = '1$0';",
+        "f5 = 'AAAAMQ';",
+        "f6 = 'AAAAMQ';"));
   }
 
   public void testNonLiteralParam1() {
@@ -593,13 +617,15 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
   }
 
   public void testConditionalCall() {
-    testError(LINE_JOINER.join(
+    testError(
+    	LINE_JOINER.join(
         "/** @idGenerator */",
         "var id = function() {}; ",
         "while(0){ id('foo');}"),
     ReplaceIdGenerators.CONDITIONAL_ID_GENERATOR_CALL);
 
-    testError(LINE_JOINER.join(
+    testError(
+    	LINE_JOINER.join(
         "/** @idGenerator */",
         "var id = function() {}; ",
         "for(;;){ id('foo');}"),
@@ -609,21 +635,24 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
             + "if(x) id('foo');",
         ReplaceIdGenerators.CONDITIONAL_ID_GENERATOR_CALL);
 
-    test("/** @consistentIdGenerator */ var id = function() {};" +
-        "function fb() {foo.bar = id('foo_bar')}",
-
-        "var id = function() {};" +
-        "function fb() {foo.bar = 'a'}",
-
-        "var id = function() {};" +
-        "function fb() {foo.bar = 'foo_bar$0'}");
+    test(
+    	LINE_JOINER.join(
+    	"/** @consistentIdGenerator */ var id = function() {};",
+        "function fb() {foo.bar = id('foo_bar')}"),
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ var id = function() {};",
+        "function fb() {foo.bar = 'a'}"),
+    	LINE_JOINER.join(
+        "/** @consistentIdGenerator */ var id = function() {};",
+        "function fb() {foo.bar = 'foo_bar$0'}"));
 
     testNonPseudoSupportingGenerator(
-        "/** @stableIdGenerator */ var id = function() {};" +
-        "function fb() {foo.bar = id('foo_bar')}",
-
-        "var id = function() {};" +
-        "function fb() {foo.bar = '125lGg'}");
+    	LINE_JOINER.join(
+        "/** @stableIdGenerator */ var id = function() {};",
+        "function fb() {foo.bar = id('foo_bar')}"),
+    	LINE_JOINER.join(
+        "/** @stableIdGenerator */ var id = function() {};",
+        "function fb() {foo.bar = '125lGg'}"));
 
     testErrorEs6(
         LINE_JOINER.join(
@@ -647,14 +676,16 @@ public final class ReplaceIdGeneratorsTest extends Es6CompilerTestCase {
             + "var id = function() {}; ",
         ReplaceIdGenerators.CONFLICTING_GENERATOR_TYPE);
 
-    test("/** @consistentIdGenerator */ var id = function() {};" +
-        "if (x) {foo.bar = id('foo_bar')}",
-
-        "var id = function() {};" +
-        "if (x) {foo.bar = 'a'}",
-
-        "var id = function() {};" +
-        "if (x) {foo.bar = 'foo_bar$0'}");
+    test(
+    	LINE_JOINER.join(
+    		"/** @consistentIdGenerator */ var id = function() {};",
+    		"if (x) {foo.bar = id('foo_bar')}"),
+    	LINE_JOINER.join(
+    		"/** @consistentIdGenerator */ var id = function() {};",
+    		"if (x) {foo.bar = 'a'}"),
+    	LINE_JOINER.join(
+    		"/** @consistentIdGenerator */ var id = function() {};",
+    		"if (x) {foo.bar = 'foo_bar$0'}"));
   }
 
   public void testUnknownMapping() {

--- a/test/com/google/javascript/jscomp/ReplaceMessagesForChromeTest.java
+++ b/test/com/google/javascript/jscomp/ReplaceMessagesForChromeTest.java
@@ -44,39 +44,60 @@ public final class ReplaceMessagesForChromeTest extends CompilerTestCase {
   @Override
   protected void setUp()  {
     style = RELAX;
-    compareJsDoc = false;
   }
 
   public void testReplaceSimpleMessage() {
-    test("/** @desc A simple message. */\n" +
-         "var MSG_A = goog.getMsg('Hello world');",
-         "var MSG_A=chrome.i18n.getMessage('8660696502365331902');");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc A simple message. */\n",
+        "var MSG_A = goog.getMsg('Hello world');"),
+    	LINE_JOINER.join(
+    	"/** @desc A simple message. */\n",
+        "var MSG_A=chrome.i18n.getMessage('8660696502365331902');"));
 
-    test("/** @desc A message attached to an object. */\n" +
-        "foo.bar.MSG_B = goog.getMsg('Goodbye world');",
-        "foo.bar.MSG_B=chrome.i18n.getMessage('2356086230621084760');");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc A message attached to an object. */\n",
+        "foo.bar.MSG_B = goog.getMsg('Goodbye world');"),
+    	LINE_JOINER.join(
+    	"/** @desc A message attached to an object. */\n",
+        "foo.bar.MSG_B=chrome.i18n.getMessage('2356086230621084760');"));
   }
 
   public void testReplaceSinglePlaceholder() {
-    test("/** @desc A message with one placeholder. */\n" +
-         "var MSG_C = goog.getMsg('Hello, {$name}', {name: 'Tyler'});",
-         "var MSG_C=chrome.i18n.getMessage('4985325380591528435', ['Tyler']);");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc A message with one placeholder. */\n",
+        "var MSG_C = goog.getMsg('Hello, {$name}', {name: 'Tyler'});"),
+    	LINE_JOINER.join(
+    	"/** @desc A message with one placeholder. */\n",		
+        "var MSG_C=chrome.i18n.getMessage('4985325380591528435', ['Tyler']);"));
   }
 
   public void testReplaceTwoPlaceholders() {
-    test("/** @desc A message with two placeholders. */\n" +
-         "var MSG_D = goog.getMsg('{$greeting}, {$name}', " +
-         "{greeting: 'Hi', name: 'Tyler'});",
-         "var MSG_D=chrome.i18n.getMessage('3605047247574980322', " +
-         "['Hi', 'Tyler']);");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc A message with two placeholders. */\n",
+        "var MSG_D = goog.getMsg('{$greeting}, {$name}', ",
+        "{greeting: 'Hi', name: 'Tyler'});"),
+    	LINE_JOINER.join(
+    	"/** @desc A message with two placeholders. */\n",
+        "var MSG_D=chrome.i18n.getMessage('3605047247574980322', ",
+        "['Hi', 'Tyler']);"));
 
-    test("/** @desc A message with two placeholders, but their order is\n" +
-         " * reversed in the object literal. (Shouldn't make a difference.)\n" +
-         " */\n" +
-         "var MSG_E = goog.getMsg('{$greeting}, {$name}!', " +
-         "{name: 'Tyler', greeting: 'Hi'});",
-         "var MSG_E=chrome.i18n.getMessage('691522386483664339', " +
-         "['Hi', 'Tyler']);");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc A message with two placeholders, but their order is\n",
+        " * reversed in the object literal. (Shouldn't make a difference.)\n",
+        " */\n",
+        "var MSG_E = goog.getMsg('{$greeting}, {$name}!', ",
+        "{name: 'Tyler', greeting: 'Hi'});"),
+    	LINE_JOINER.join(
+		"/** @desc A message with two placeholders, but their order is\n",
+	    " * reversed in the object literal. (Shouldn't make a difference.)\n",
+	    " */\n",
+        "var MSG_E=chrome.i18n.getMessage('691522386483664339', ",
+        "['Hi', 'Tyler']);"));
   }
 
   public void testReplacePlaceholderMissingValue() {
@@ -86,17 +107,25 @@ public final class ReplaceMessagesForChromeTest extends CompilerTestCase {
   }
 
   public void testReplaceTwoPlaceholdersNonAlphaOrder() {
-    test("/** @desc A message with two placeholders not in order .*/\n" +
-         "var MSG_G = goog.getMsg('{$name}: {$greeting}', " +
-         "{greeting: 'Salutations', name: 'Tyler'});",
-         "var MSG_G=chrome.i18n.getMessage('7437383242562773138', " +
-         "['Salutations', 'Tyler']);");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc A message with two placeholders not in order .*/\n",
+        "var MSG_G = goog.getMsg('{$name}: {$greeting}', ",
+        "{greeting: 'Salutations', name: 'Tyler'});"),
+    	LINE_JOINER.join(
+        "/** @desc A message with two placeholders not in order .*/\n",
+        "var MSG_G=chrome.i18n.getMessage('7437383242562773138', ",
+        "['Salutations', 'Tyler']);"));
   }
 
   public void testReplaceExternalMessage() {
-    test("/** @desc A message that was extracted with SoyMsgExtractor. */\n" +
-         "var MSG_EXTERNAL_1357902468 = goog.getMsg('Hello world');",
-         "var MSG_EXTERNAL_1357902468 = chrome.i18n.getMessage('1357902468');");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc A message that was extracted with SoyMsgExtractor. */\n",
+        "var MSG_EXTERNAL_1357902468 = goog.getMsg('Hello world');"),
+    	LINE_JOINER.join(
+    	"/** @desc A message that was extracted with SoyMsgExtractor. */\n",
+        "var MSG_EXTERNAL_1357902468 = chrome.i18n.getMessage('1357902468');"));
   }
 
   /**
@@ -104,26 +133,25 @@ public final class ReplaceMessagesForChromeTest extends CompilerTestCase {
    * placeholder twice.
    */
   public void testReplaceMessageWithDuplicatePlaceholders() {
-    String original = "" +
-        "/** @desc A message that contains two instances of the same placeholder. */\n" +
-        "var MSG_EXTERNAL_987654321 = goog.getMsg(" +
-        "'{$startDiv_1}You are signed in as{$endDiv}{$img}{$startDiv_2}{$name}{$endDiv}'," +
-        "{'startDiv_1': '<div>'," +
-        "'endDiv': '</div>'," +
-        "'img': '<img src=\"http://example.com/photo.png\">'," +
-        "'startDiv_2': '<div class=\"name\">'," +
-        "'name': name});";
-
-    String compiled = "" +
-        "var MSG_EXTERNAL_987654321 = chrome.i18n.getMessage('987654321', " +
-        "[" +
-        "'</div>', " +  // endDiv, only included once, even though it appears twice in the message.
-        "'<img src=\"http://example.com/photo.png\">', " +  // img
-        "name, " +  // name
-        "'<div>', " +  // startDiv_1
-        "'<div class=\"name\">'" +  // startDiv_2
-        "]);";
-
-    test(original, compiled);
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc A message that contains two instances of the same placeholder. */\n",
+        "var MSG_EXTERNAL_987654321 = goog.getMsg(",
+        "'{$startDiv_1}You are signed in as{$endDiv}{$img}{$startDiv_2}{$name}{$endDiv}',",
+        "{'startDiv_1': '<div>',",
+        "'endDiv': '</div>',",
+        "'img': '<img src=\"http://example.com/photo.png\">',",
+        "'startDiv_2': '<div class=\"name\">',",
+        "'name': name});"),
+    	LINE_JOINER.join(
+    	"/** @desc A message that contains two instances of the same placeholder. */\n",
+        "var MSG_EXTERNAL_987654321 = chrome.i18n.getMessage('987654321', ",
+        "[",
+        "'</div>', ",  // endDiv, only included once, even though it appears twice in the message.
+        "'<img src=\"http://example.com/photo.png\">', ",  // img
+        "name, ",  // name
+        "'<div>', ",  // startDiv_1
+        "'<div class=\"name\">'",  // startDiv_2
+        "]);"));
   }
 }

--- a/test/com/google/javascript/jscomp/ReplaceMessagesTest.java
+++ b/test/com/google/javascript/jscomp/ReplaceMessagesTest.java
@@ -51,7 +51,6 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
     messages = new HashMap<>();
     strictReplacement = false;
     style = RELAX;
-    compareJsDoc = false;
   }
 
   public void testReplaceSimpleMessage() {
@@ -59,9 +58,13 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
         .appendStringPart("Hi\nthere")
         .build());
 
-    test("/** @desc d */\n" +
-         "var MSG_A = goog.getMsg('asdf');",
-         "var MSG_A=\"Hi\\nthere\"");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_A = goog.getMsg('asdf');"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_A=\"Hi\\nthere\""));
   }
 
   public void testNameReplacement()  {
@@ -71,9 +74,13 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
         .appendStringPart(" ph")
         .build());
 
-    test("/** @desc d */\n" +
-         "var MSG_B=goog.getMsg('asdf {$measly}', {measly: x});",
-         "var MSG_B=\"One \"+ (x +\" ph\" )");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_B=goog.getMsg('asdf {$measly}', {measly: x});"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_B=\"One \"+ (x +\" ph\" )"));
   }
 
   public void testGetPropReplacement()  {
@@ -81,9 +88,13 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
         .appendPlaceholderReference("amount")
         .build());
 
-    test("/** @desc d */\n" +
-         "var MSG_C = goog.getMsg('${$amount}', {amount: a.b.amount});",
-         "var MSG_C=a.b.amount");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+    	"var MSG_C = goog.getMsg('${$amount}', {amount: a.b.amount});"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_C=a.b.amount"));
   }
 
   public void testFunctionCallReplacement()  {
@@ -91,9 +102,13 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
         .appendPlaceholderReference("amount")
         .build());
 
-    test("/** @desc d */\n" +
-         "var MSG_D = goog.getMsg('${$amount}', {amount: getAmt()});",
-         "var MSG_D=getAmt()");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_D = goog.getMsg('${$amount}', {amount: getAmt()});"),
+    	LINE_JOINER.join(
+        "/** @desc d */\n",
+        "var MSG_D=getAmt()"));
   }
 
   public void testMethodCallReplacement()  {
@@ -101,9 +116,13 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
         .appendPlaceholderReference("amount")
         .build());
 
-    test("/** @desc d */\n" +
-         "var MSG_E = goog.getMsg('${$amount}', {amount: obj.getAmt()});",
-         "var MSG_E=obj.getAmt()");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_E = goog.getMsg('${$amount}', {amount: obj.getAmt()});"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+    	"var MSG_E=obj.getAmt()"));
   }
 
   public void testHookReplacement()  {
@@ -113,9 +132,13 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
         .appendStringPart(".")
         .build());
 
-    test("/** @desc d */\n" +
-         "var MSG_F = goog.getMsg('${$amount}', {amount: (a ? b : c)});",
-         "var MSG_F=\"#\"+((a?b:c)+\".\")");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_F = goog.getMsg('${$amount}', {amount: (a ? b : c)});"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_F=\"#\"+((a?b:c)+\".\")"));
   }
 
   public void testAddReplacement()  {
@@ -123,9 +146,13 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
         .appendPlaceholderReference("amount")
         .build());
 
-    test("/** @desc d */\n" +
-         "var MSG_G = goog.getMsg('${$amount}', {amount: x + ''});",
-         "var MSG_G=x+\"\"");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_G = goog.getMsg('${$amount}', {amount: x + ''});"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_G=x+\"\""));
   }
 
   public void testPlaceholderValueReferencedTwice()  {
@@ -137,9 +164,13 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
         .appendPlaceholderReference("jane")
         .build());
 
-    test("/** @desc d */\n" +
-         "var MSG_H = goog.getMsg('{$dick}{$jane}', {jane: x, dick: y});",
-         "var MSG_H=y+(\", \"+(y+(\" and \"+x)))");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_H = goog.getMsg('{$dick}{$jane}', {jane: x, dick: y});"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_H=y+(\", \"+(y+(\" and \"+x)))"));
   }
 
   public void testPlaceholderNameInLowerCamelCase()  {
@@ -148,9 +179,13 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
         .appendPlaceholderReference("amtEarned")
         .build());
 
-    test("/** @desc d */\n" +
-         "var MSG_I = goog.getMsg('${$amtEarned}', {amtEarned: x});",
-         "var MSG_I=\"Sum: $\"+x");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_I = goog.getMsg('${$amtEarned}', {amtEarned: x});"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_I=\"Sum: $\"+x"));
   }
 
   public void testQualifiedMessageName()  {
@@ -160,9 +195,13 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
         .appendStringPart(" ph")
         .build());
 
-    test("/** @desc d */\n" +
-         "a.b.c.MSG_J = goog.getMsg('asdf {$measly}', {measly: x});",
-         "a.b.c.MSG_J=\"One \"+(x+\" ph\")");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+    	"a.b.c.MSG_J = goog.getMsg('asdf {$measly}', {measly: x});"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "a.b.c.MSG_J=\"One \"+(x+\" ph\")"));
   }
 
   public void testPlaceholderInPlaceholderValue()  {
@@ -172,22 +211,34 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
         .appendPlaceholderReference("b")
         .build());
 
-    test("/** @desc d */\n" +
-         "var MSG_L = goog.getMsg('{$a} has {$b}', {a: '{$b}', b: 1});",
-         "var MSG_L=\"{$b}\"+(\" has \"+1);");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_L = goog.getMsg('{$a} has {$b}', {a: '{$b}', b: 1});"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_L=\"{$b}\"+(\" has \"+1);"));
   }
   public void testSimpleMessageReplacementMissing()  {
     style = Style.LEGACY;
-    test("/** @desc d */\n" +
-         "var MSG_E = 'd*6a0@z>t';",
-         "var MSG_E = 'd*6a0@z>t'");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_E = 'd*6a0@z>t';"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_E = 'd*6a0@z>t'"));
   }
 
 
   public void testSimpleMessageReplacementMissingWithNewStyle()  {
-    test("/** @desc d */\n" +
-         "var MSG_E = goog.getMsg('missing');",
-         "var MSG_E = 'missing'");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_E = goog.getMsg('missing');"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_E = 'missing'"));
   }
 
   public void testStrictModeAndMessageReplacementAbsentInBundle()  {
@@ -374,53 +425,73 @@ public final class ReplaceMessagesTest extends CompilerTestCase {
     registerMessage(new JsMessage.Builder("MSG_B")
         .appendStringPart("translated")
         .build());
-    test("/** @desc d */\n" +
-         "var MSG_A = goog.getMsg('msg A');" +
-         "/** @desc d */\n" +
-         "var MSG_B = goog.getMsg('msg B');" +
-         "var x = goog.getMsgWithFallback(MSG_A, MSG_B);",
-         "var MSG_A = 'msg A';" +
-         "var MSG_B = 'translated';" +
-         "var x = MSG_B;");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_A = goog.getMsg('msg A');",
+        "/** @desc d */\n",
+        "var MSG_B = goog.getMsg('msg B');",
+        "var x = goog.getMsgWithFallback(MSG_A, MSG_B);"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_A = 'msg A';",
+        "/** @desc d */\n",
+        "var MSG_B = 'translated';",
+        "var x = MSG_B;"));
   }
 
   public void testFallbackEmptyBundle() {
-    test("/** @desc d */\n" +
-         "var MSG_A = goog.getMsg('msg A');" +
-         "/** @desc d */\n" +
-         "var MSG_B = goog.getMsg('msg B');" +
-         "var x = goog.getMsgWithFallback(MSG_A, MSG_B);",
-         "var MSG_A = 'msg A';" +
-         "var MSG_B = 'msg B';" +
-         "var x = MSG_A;");
+    test(
+		LINE_JOINER.join(
+		"/** @desc d */\n",
+        "var MSG_A = goog.getMsg('msg A');",
+        "/** @desc d */\n",
+        "var MSG_B = goog.getMsg('msg B');",
+        "var x = goog.getMsgWithFallback(MSG_A, MSG_B);"),
+        LINE_JOINER.join(
+        "/** @desc d */\n",
+        "var MSG_A = 'msg A';",
+        "/** @desc d */\n",
+        "var MSG_B = 'msg B';",
+        "var x = MSG_A;"));
   }
 
   public void testNoUseFallback() {
     registerMessage(new JsMessage.Builder("MSG_A")
         .appendStringPart("translated")
         .build());
-    test("/** @desc d */\n" +
-         "var MSG_A = goog.getMsg('msg A');" +
-         "/** @desc d */\n" +
-         "var MSG_B = goog.getMsg('msg B');" +
-         "var x = goog.getMsgWithFallback(MSG_A, MSG_B);",
-         "var MSG_A = 'translated';" +
-         "var MSG_B = 'msg B';" +
-         "var x = MSG_A;");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_A = goog.getMsg('msg A');",
+        "/** @desc d */\n",
+        "var MSG_B = goog.getMsg('msg B');",
+        "var x = goog.getMsgWithFallback(MSG_A, MSG_B);"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_A = 'translated';",
+        "/** @desc d */\n",
+        "var MSG_B = 'msg B';",
+        "var x = MSG_A;"));
   }
 
   public void testNoUseFallback2() {
     registerMessage(new JsMessage.Builder("MSG_C")
         .appendStringPart("translated")
         .build());
-    test("/** @desc d */\n" +
-         "var MSG_A = goog.getMsg('msg A');" +
-         "/** @desc d */\n" +
-         "var MSG_B = goog.getMsg('msg B');" +
-         "var x = goog.getMsgWithFallback(MSG_A, MSG_B);",
-         "var MSG_A = 'msg A';" +
-         "var MSG_B = 'msg B';" +
-         "var x = MSG_A;");
+    test(
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_A = goog.getMsg('msg A');",
+        "/** @desc d */\n",
+        "var MSG_B = goog.getMsg('msg B');",
+        "var x = goog.getMsgWithFallback(MSG_A, MSG_B);"),
+    	LINE_JOINER.join(
+    	"/** @desc d */\n",
+        "var MSG_A = 'msg A';",
+        "/** @desc d */\n",
+        "var MSG_B = 'msg B';",
+        "var x = MSG_A;"));
   }
 
   private void registerMessage(JsMessage message) {

--- a/test/com/google/javascript/jscomp/ReplaceStringsTest.java
+++ b/test/com/google/javascript/jscomp/ReplaceStringsTest.java
@@ -80,7 +80,6 @@ public final class ReplaceStringsTest extends CompilerTestCase {
     super(EXTERNS, true);
     enableNormalize();
     parseTypeInfo = true;
-    compareJsDoc = false;
   }
 
   @Override
@@ -229,28 +228,30 @@ public final class ReplaceStringsTest extends CompilerTestCase {
 
   public void testThrowError4() {
     testDebugStrings(
-        "/** @constructor */\n" +
-        "var A = function() {};\n" +
-        "A.prototype.m = function(child) {\n" +
-        "  if (this.haveChild(child)) {\n" +
-        "    throw Error('Node: ' + this.getDataPath() +\n" +
-        "                ' already has a child named ' + child);\n" +
-        "  } else if (child.parentNode) {\n" +
-        "    throw Error('Node: ' + child.getDataPath() +\n" +
-        "                ' already has a parent');\n" +
-        "  }\n" +
-        "  child.parentNode = this;\n" +
-        "};",
-
-        "var A = function(){};\n" +
-        "A.prototype.m = function(child) {\n" +
-        "  if (this.haveChild(child)) {\n" +
-        "    throw Error('a' + '`' + this.getDataPath() + '`' + child);\n" +
-        "  } else if (child.parentNode) {\n" +
-        "    throw Error('b' + '`' + child.getDataPath());\n" +
-        "  }\n" +
-        "  child.parentNode = this;\n" +
-        "};",
+    	LINE_JOINER.join(
+        "/** @constructor */\n",
+        "var A = function() {};\n",
+        "A.prototype.m = function(child) {\n",
+        "  if (this.haveChild(child)) {\n",
+        "    throw Error('Node: ' + this.getDataPath() +\n",
+        "                ' already has a child named ' + child);\n",
+        "  } else if (child.parentNode) {\n",
+        "    throw Error('Node: ' + child.getDataPath() +\n",
+        "                ' already has a parent');\n",
+        "  }\n",
+        "  child.parentNode = this;\n", 
+        "};"),
+    	LINE_JOINER.join(
+    	"/** @constructor */\n",
+        "var A = function(){};\n",
+        "A.prototype.m = function(child) {\n",
+        "  if (this.haveChild(child)) {\n",
+        "    throw Error('a' + '`' + this.getDataPath() + '`' + child);\n",
+        "  } else if (child.parentNode) {\n",
+        "    throw Error('b' + '`' + child.getDataPath());\n",
+        "  }\n",
+        "  child.parentNode = this;\n",
+        "};"),
         (new String[] {
             "a",
             "Node: ` already has a child named `",
@@ -512,37 +513,53 @@ public final class ReplaceStringsTest extends CompilerTestCase {
     builder.add("C.prototype.f(?)");
     functionsToInspect = builder.build();
 
-    String js =
-        "/** @constructor */function A() {}\n"
-        + "/** @param {string} p\n"
-        + "  * @return {string} */\n"
-        + "A.prototype.f = function(p) {return 'a' + p;};\n"
-        + "/** @constructor */function B() {}\n"
-        + "/** @param {string} p\n"
-        + "  * @return {string} */\n"
-        + "B.prototype.f = function(p) {return p + 'b';};\n"
-        + "/** @constructor */function C() {}\n"
-        + "/** @param {string} p\n"
-        + "  * @return {string} */\n"
-        + "C.prototype.f = function(p) {return 'c' + p + 'c';};\n"
-        + "/** @type {A|B} */var ab = 1 ? new B : new A;\n"
-        + "/** @type {string} */var n = ab.f('not replaced');\n"
-        + "(new A).f('replaced with a');"
-        + "(new C).f('replaced with b');";
-
-    String output =
-        "function A() {}\n"
-        + "A.prototype.A_prototype$f = function(p) { return'a'+p; };\n"
-        + "function B() {}\n"
-        + "B.prototype.A_prototype$f = function(p) { return p+'b'; };\n"
-        + "function C() {}\n"
-        + "C.prototype.C_prototype$f = function(p) { return'c'+p+'c'; };\n"
-        + "var ab = 1 ? new B : new A;\n"
-        + "var n = ab.A_prototype$f('not replaced');\n"
-        + "(new A).A_prototype$f('a');"
-        + "(new C).C_prototype$f('b');";
-
-    testDebugStrings(js, output,
+    testDebugStrings(
+    	LINE_JOINER.join(
+    	"/** @constructor */",
+        "function A() {}\n",
+        "/** @param {string} p\n",
+        "  * @return {string} */\n",
+        "A.prototype.f = function(p) {return 'a' + p;};\n",
+        "/** @constructor */",
+        "function B() {}\n",
+        "/** @param {string} p\n",
+        "  * @return {string} */\n",
+        "B.prototype.f = function(p) {return p + 'b';};\n",
+        "/** @constructor */",
+        "function C() {}\n",
+        "/** @param {string} p\n",
+        "  * @return {string} */\n",
+        "C.prototype.f = function(p) {return 'c' + p + 'c';};\n",
+        "/** @type {A|B} */",
+        "var ab = 1 ? new B : new A;\n",
+        "/** @type {string} */",
+        "var n = ab.f('not replaced');\n",
+        "(new A).f('replaced with a');",
+        "(new C).f('replaced with b');"),
+    	
+    	LINE_JOINER.join(
+    	"/** @constructor */",
+    	"function A() {}\n",
+    	"/** @param {string} p\n",
+    	"  * @return {string} */\n",
+    	"A.prototype.A_prototype$f = function(p) { return'a'+p; };\n",
+    	"/** @constructor */",
+    	"function B() {}\n",
+    	"/** @param {string} p\n",
+    	"  * @return {string} */\n",
+    	"B.prototype.A_prototype$f = function(p) { return p+'b'; };\n",
+    	"/** @constructor */",
+    	"function C() {}\n",
+    	"/** @param {string} p\n",
+    	"  * @return {string} */\n",
+    	"C.prototype.C_prototype$f = function(p) { return'c'+p+'c'; };\n",
+    	"/** @type {A|B} */",
+    	"var ab = 1 ? new B : new A;\n",
+    	"/** @type {string} */",
+    	"var n = ab.A_prototype$f('not replaced');\n",
+    	"(new A).A_prototype$f('a');",
+    	"(new C).C_prototype$f('b');"),
+        
         new String[] {
             "a", "replaced with a",
             "b", "replaced with b"});


### PR DESCRIPTION
Turn on compareJsDoc for all test files except Es6InlineTypesTest and JsdocToEs6TypedConverterTest. Tries to fix issue [#1396](https://github.com/google/closure-compiler/issues/1396). Now one single commit.